### PR TITLE
Cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ log
 
 # virtualenv
 env/
+
+# Redis persistence
+dump.rdb

--- a/app/models.py
+++ b/app/models.py
@@ -79,10 +79,10 @@ class Entity(Base):
         self.name = name
 
     def __repr__(self):
-        return '<Entity %r>' % (self.id)
+        return "%s %s" % (self.__class__.__name__, self.id)
 
     def delete_memoized_json(self):
-        print("delete_memoized_json for Entity %(id)s" % { 'id': self.id })
+        print("delete_memoized_json for %(self)s" % { 'self': self })
         cache.delete_memoized(self.json)
 
     @cache.memoize(timeout=None)
@@ -118,8 +118,7 @@ class Entity(Base):
 
 @event.listens_for(Entity, 'after_update')
 def receive_after_update(mapper, connection, target):
-    """Listen for the 'after_update' event"""
-    print("receive_after_update for Entity %(id)s" % { 'id': target.id })
+    print("receive_after_update for %(target)s" % { 'target': target })
     target.delete_memoized_json()
 
 class Category(Base):

--- a/app/views.py
+++ b/app/views.py
@@ -88,7 +88,7 @@ def categories():
 
 
 def nodes():
-    return [entity.json() for entity in Entity.query.all()]
+    return Entity.all_as_json()
 
 
 def edits():

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+import click
+from flask.cli import FlaskGroup
+from app import app
+from app.models import Entity, Edit, Category, Revenue, Expense, Fundingconnection, Dataconnection, \
+    Collaboration, Employment, Relation
+from config import FLASK_SESSION_SECRET_KEY
+
+def app_factory(info):
+    app.secret_key = FLASK_SESSION_SECRET_KEY
+    return app
+
+@click.group(cls=FlaskGroup, create_app=app_factory)
+def cli():
+    """This is a management script for the application."""
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
This pushes caching down to the model level, caching individual serialized object representations rather than entire view responses.

This is good and bad.

Good: this means that when a cached object is updated (e.g. a new connection is created between entities, or a new person is added to the graph) only its serialized representation needs to be recreated and cached (rather than blowing away and regenerating the entire view response, which can take minutes and effectively cause the application to become unresponsive).

Bad: because entire view responses are no longer cached, endpoint response times will increase by an order of magnitude here (empirically from ~10ms to ~400ms). This is acceptable as a temporary solution to the breakage mentioned above. However, view caching should still be reinstated atop the model caching. This PR does not include view caching so as to release one layer of caching at a time, for cleaner releases.