### PR TITLE
Update location

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -351,9 +351,18 @@ def update(entity, data):
         for location in locations:
             if 'id' in location and location['id']:
                 # Location exists, update.
-                oldlocation = Location.query.get(location['id'])
+                oldlocation = Location.query.get(location['id'])  # get old location from db query & replace
                 update_location(oldlocation, location)
             else:
-                update_locations(data['locations'])
+                #Save a new location
+                new_location = Location()
+                db.add(new_location)
+                db.commit()
+                #create relationship between new location and entity
+                new_location.entities=[entity]
+                update_location(new_location, location)
+
+
+    update_locations(data['locations'])
 
     db.commit()

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import logging
 from flask import Flask
 from flask_cache import Cache
 from flask_redis import FlaskRedis
@@ -7,9 +8,16 @@ from database import db
 redis_store = FlaskRedis()
 
 def create_app():
+    handler=logging.FileHandler('log/flask.log')
+    handler.setLevel(logging.DEBUG)
+
     app = Flask(__name__)
     app.config.from_pyfile('../config.py')
     redis_store.init_app(app)
+
+    app.logger.addHandler(handler)
+    app.logger.setLevel(logging.DEBUG)
+
     return app
 
 app = create_app()


### PR DESCRIPTION
Previously, an entity whose location had already been set had the function to uupdate location. However, entities who did not have a given location could not add a new location. The code had not been written to update the entity's location, and the function itself did not support this feature. Both the entity's call and its subsequent function have been fixed.

Signed-off-by: Briana Vecchione <briana.vecchione@gmail.com>